### PR TITLE
Add include statements required for CentOS 6.7

### DIFF
--- a/options.c
+++ b/options.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include "options.h"
 
 void show_help();


### PR DESCRIPTION
Good job and I really enjoy the on-console-minesweeper-game.

However, on my compuer (`CentOS 6.7` and `GCC 4.4.7`), I couldn't compile the programs because of the following error:

```
options.c:68: error: ‘pid_t’ undeclared (first use in this function)
```

This change will fix the problem. I added three #include lines in `options.c`:
- `#include <sys/types.h>` is required for using `pid_t`
- `#include <sys/wait.h>` is required to remove warning of `implicit declaration of function 'waitpid'`
- `#include <unistd.h>` is required to remove warning of `implicit declaration of function 'fork' and 'execv'`

Does this change also work on your computer? I will appriciate if you merge this pull request.

Thanks!
