### PR TITLE
fix hang, version number

### DIFF
--- a/options.c
+++ b/options.c
@@ -29,7 +29,7 @@ struct tm_options parse_options(int argc, char **argv)
 									.mine_density = 0.1,
 									.adventure_mode = false};
 
-	char param;
+	signed char param;
 	while ((param = getopt_long(argc, argv, "w:h:m:va", options, NULL)) != -1) {
 		switch (param) {
 		case 'w': {

--- a/options.c
+++ b/options.c
@@ -98,5 +98,5 @@ void show_help()
 
 void print_version()
 {
-	puts("1.1.0");
+	puts("1.2.0");
 }


### PR DESCRIPTION
1. Fix hang due to unsigned char, warned about below. This caused it to hang forever when starting.

```
options.c:33:70: warning: result of comparison of constant -1 with expression of type 'char' is always true [-Wtautological-constant-out-of-range-compare]                              while ((param = getopt_long(argc, argv, "w:h:m:va", options, NULL)) != -1) {                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~
1 warning generated.
cc -Llibminesweeper  terminal-mines.o libminesweeper/libminesweeper.a graphics.o options.o  -lncurses -lminesweeper -o terminal-mines
```

2. Fix version number. The current release represents itself as 1.1.0, despite being tagged 1.2.0.