### PR TITLE
Flag/open tiles with space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 terminal-mines
 compile_commands.json
+*.o

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ terminal-mines -w 20 -h 20 -m 0.5
 - Movement: `hjkl` or arrow keys
 - Place flag: `f` or `g`
 - Open tile: `,`
+- Place flag on unopened tile & open adjacent tiles of opened tile: ` `
 
 The controls were inspired by nethack/vim.
 

--- a/terminal-mines.c
+++ b/terminal-mines.c
@@ -151,7 +151,10 @@ void game_loop(WINDOW *window, struct minesweeper_game *game, struct tm_options 
 			minesweeper_toggle_flag(game, game->selected_tile);
 			update_status_window(status_win, game);
 			break;
-
+		case ' ':
+			minesweeper_space_tile(game, game->selected_tile);
+			update_status_window(status_win, game);
+			break;
 		case ',':
 			minesweeper_open_tile(game, game->selected_tile);
 			update_status_window(status_win, game);


### PR DESCRIPTION
Add support for using space to flag unopened tiles and open adjacent tiles to a number if correct number of tiles are flagged. Controls are as described in the: `https://minesweeperonline.com/#` version.